### PR TITLE
Fix inconsistent API, Javadocs and demos

### DIFF
--- a/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.splitlayout;
 
-import java.util.Optional;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.HasSize;
@@ -24,8 +22,117 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.dom.ElementConstants;
 import com.vaadin.flow.shared.Registration;
 
+import java.util.Objects;
+import java.util.Optional;
+
 /**
- * Server-side component for the {@code <vaadin-split-layout>} element.
+ * <p>
+ * {@code SplitLayout} is a component based on the {@code vaadin-split-layout}
+ * Polymer element implementing a split layout for two content elements with a
+ * draggable splitter between them. DOM Example:
+ * </p>
+ * <code>
+ * &lt;vaadin-split-layout&gt;<br>
+ * &lt;div&gt;First content element&lt;/div&gt;<br>
+ * &lt;div&gt;Second content element&lt;/div&gt;<br>
+ * &lt;/vaadin-split-layout&gt;
+ * </code>
+ * <h3>Horizontal and Vertical Layouts</h3>
+ * <p>
+ * By default, the split's orientation is horizontal, meaning that the content
+ * elements are positioned side by side in a flex container with a horizontal
+ * layout. You can change the split mode to vertical by using the {@link #setOrientation(Orientation)}
+ * with {@link Orientation#VERTICAL}.
+ * </p>
+ * The {@code <vaadin-split-layout>} element itself is a flex container. It does not
+ * inherit the parent height by default, but rather sets its height depending on
+ * the content.
+ * </p>
+ * <p>
+ * You can use CSS to set the fixed height for the split layout, as usual with
+ * any block element. It is possible to define percentage height as well.
+ * Note that you have to set the parent height in order to make percentages work correctly.
+ * </p>
+ * <h3>Initial Splitter Position</h3>
+ * <p>
+ * The initial splitter position is determined from the sizes of the content
+ * elements inside the split layout. Therefore, changing width on the
+ * content components affects the initial splitter position for the horizontal
+ * layouts, while height affects the vertical ones.
+ * </p>
+ * <p>
+ * Note that when the total size of the content component does not fit the
+ * layout, the content elements are scaled proportionally.
+ * </p>
+ * <p>
+ * When setting initial sizes with relative units, such as percentages, it is
+ * recommended to assign the size for both content elements:
+ * </p>
+ * <p>
+ * <code>
+ * SplitLayout layout = new SplitLayout();
+ * <p>
+ * Label first = new Label("First is 1/4");<br>
+ * first.setWidth("25%");<br>
+ * layout.addToPrimary(first);<br>
+ * <p>
+ * Label second = new Label("Second is 3/4");<br>
+ * second.setWidth("75%");<br>
+ * layout.addToSecondary(second);
+ * </code>
+ * </p>
+ * <h3>Size Limits</h3>
+ * <p>
+ * The {@code min-width}/{@code min-height}, and {@code max-width}/
+ * {@code max-height} CSS size values for the content elements are respected and
+ * used to limit the splitter position when it is dragged.
+ * </p>
+ * <p>
+ * It is preferred to set the limits only for a single content element, in order
+ * to avoid size conflicts:
+ * </p>
+ * <p>
+ * <code>
+ * SplitLayout layout = new SplitLayout();<br>
+ * layout.addToPrimary(new Label("First"));<br>
+ * layout.addToPrimary(new Label("Second with min & max size");<br>
+ * layout.setSecondaryStyle("min-width", "200px");<br>
+ * layout.setSecondaryStyle("max-width", "600px");
+ * </code>
+ * </p>
+ * <h3>Resize Notification</h3>
+ * <p>
+ * For notification on when the user has resized the split position, use the {@link #addSplitterDragendListener(ComponentEventListener)}.
+ * </p>
+ * <h3>Styling</h3>
+ * <p>
+ * The following shadow DOM parts are available for styling:
+ * </p>
+ * <table>
+ * <thead>
+ * <tr>
+ * <th>Part name</th>
+ * <th>Description</th>
+ * <th>Theme for Element</th>
+ * </tr>
+ * </thead> <tbody>
+ * <tr>
+ * <td>{@code splitter}</td>
+ * <td>Split element</td>
+ * <td>vaadin-split-layout</td>
+ * </tr>
+ * <tr>
+ * <td>{@code handle}</td>
+ * <td>The handle of the splitter</td>
+ * <td>vaadin-split-layout</td>
+ * </tr>
+ * </tbody>
+ * </table>
+ * <p>
+ * See <a
+ * href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin –
+ * how to apply styles for shadow parts</a>
+ * </p>
  *
  * @author Vaadin Ltd
  */
@@ -46,41 +153,51 @@ public class SplitLayout extends GeneratedVaadinSplitLayout<SplitLayout>
      * Constructs an empty VaadinSplitLayout.
      */
     public SplitLayout() {
+        setOrientation(Orientation.HORIZONTAL);
     }
 
     /**
      * Constructs a VaadinSplitLayout with the given initial components to set
      * to the primary and secondary splits.
      *
-     * @param primaryComponent
-     *            the component set to the primary split
-     * @param secondaryComponent
-     *            the component set to the secondary split
+     * @param primaryComponent   the component set to the primary split
+     * @param secondaryComponent the component set to the secondary split
      */
     public SplitLayout(Component primaryComponent,
-            Component secondaryComponent) {
+                       Component secondaryComponent) {
+        this();
         addToPrimary(primaryComponent);
         addToSecondary(secondaryComponent);
     }
 
     /**
      * Set the orientation of the SplitLayout.
-     * 
-     * @param orientation
-     *            the orientation of the SplitLayout. Valid enumerate values are
-     *            VERTICAL and HORIZONTAL.
+     * <p>
+     * Default value is {@link Orientation#HORIZONTAL}.
+     *
+     *
+     * @param orientation the orientation of the SplitLayout. Valid enumerate values are
+     *                    VERTICAL and HORIZONTAL, never {@code null}
      */
     public void setOrientation(Orientation orientation) {
+        Objects.requireNonNull(orientation, "Orientation cannot be null");
         this.setOrientation(orientation.toString().toLowerCase());
     }
 
     /**
      * Get the orientation of the SplitLayout.
-     * 
+     * <p>
+     * Default value is {@link Orientation#HORIZONTAL}.
+     * <p>
+     * <em>NOTE:</em> This property is not synchronized automatically from the client side, so
+     * the returned value may not be the same as in client side.
+     * </p>
+
+     *
      * @return the {@code orientation} property of the SplitLayout.
      */
-    protected String getOrientation() {
-        return super.getOrientationString();
+    public Orientation getOrientation() {
+        return Orientation.valueOf(super.getOrientationString().toUpperCase());
     }
 
     /**
@@ -94,8 +211,8 @@ public class SplitLayout extends GeneratedVaadinSplitLayout<SplitLayout>
      * will move the secondary component to the primary split, causing this
      * layout to desync with the server. This is a known issue.
      *
-     * @see #setVertical(boolean)
      * @return this instance, for method chaining
+     * @see #setOrientation(Orientation)
      */
     @Override
     public SplitLayout addToPrimary(Component... components) {
@@ -126,8 +243,8 @@ public class SplitLayout extends GeneratedVaadinSplitLayout<SplitLayout>
      * <b>Note:</b> Calling this method with multiple arguments will wrap the
      * components inside a {@code <div>} element.
      *
-     * @see #setVertical(boolean)
      * @return this instance, for method chaining
+     * @see #setOrientation(Orientation)
      */
     @Override
     public SplitLayout addToSecondary(Component... components) {
@@ -157,48 +274,39 @@ public class SplitLayout extends GeneratedVaadinSplitLayout<SplitLayout>
      * of the component and in vertical mode this is the height. The given value
      * will automatically be clamped to the range [0, 100].
      *
-     * @param position
-     *            the relative position of the splitter, in percentages
-     * @return this instance, for method chaining
+     * @param position the relative position of the splitter, in percentages
      */
-    public SplitLayout setSplitterPosition(double position) {
+    public void setSplitterPosition(double position) {
         double primary = Math.min(Math.max(position, 0), 100);
         double secondary = 100 - primary;
         String styleName;
-        if (getOrientation() == "vertical") {
+        if (getOrientation() == Orientation.VERTICAL) {
             styleName = ElementConstants.STYLE_HEIGHT;
         } else {
             styleName = ElementConstants.STYLE_WIDTH;
         }
         setPrimaryStyle(styleName, primary + "%");
         setSecondaryStyle(styleName, secondary + "%");
-        return get();
     }
 
     /**
      * Set a style to the component in the primary split.
      *
-     * @param styleName
-     *            name of the style to set
-     * @param value
-     *            the value to set
-     * @return this instance, for method chaining
+     * @param styleName name of the style to set
+     * @param value     the value to set
      */
-    public SplitLayout setPrimaryStyle(String styleName, String value) {
-        return setInnerComponentStyle(primaryComponent, styleName, value);
+    public void setPrimaryStyle(String styleName, String value) {
+        setInnerComponentStyle(primaryComponent, styleName, value);
     }
 
     /**
      * Set a style to the component in the secondary split.
      *
-     * @param styleName
-     *            name of the style to set
-     * @param value
-     *            the value to set
-     * @return this instance, for method chaining
+     * @param styleName name of the style to set
+     * @param value     the value to set
      */
-    public SplitLayout setSecondaryStyle(String styleName, String value) {
-        return setInnerComponentStyle(secondaryComponent, styleName, value);
+    public void setSecondaryStyle(String styleName, String value) {
+        setInnerComponentStyle(secondaryComponent, styleName, value);
     }
 
     private SplitLayout setComponents() {
@@ -217,21 +325,25 @@ public class SplitLayout extends GeneratedVaadinSplitLayout<SplitLayout>
     }
 
     @Override
-    public Registration addIronResizeListener(
-            ComponentEventListener<IronResizeEvent<SplitLayout>> listener) {
-        return super.addIronResizeListener(listener);
-    }
-
-    @Override
     public void remove(Component... components) {
         super.remove(components);
     }
 
+    /**
+     * Removes the primary and the secondary components.
+     */
     @Override
     public void removeAll() {
         super.removeAll();
     }
 
+    /**
+     * Adds a listener for the {@code splitter-dragend} event, which is fired when the user has stopped resizing the
+     * splitter with drag and drop.
+     *
+     * @param listener the listener to add
+     * @return a registration for removing the listener
+     */
     @Override
     public Registration addSplitterDragendListener(
             ComponentEventListener<SplitterDragendEvent<SplitLayout>> listener) {
@@ -239,7 +351,7 @@ public class SplitLayout extends GeneratedVaadinSplitLayout<SplitLayout>
     }
 
     private SplitLayout setInnerComponentStyle(Component innerComponent,
-            String styleName, String value) {
+                                               String styleName, String value) {
         Optional.ofNullable(innerComponent).ifPresent(component -> component
                 .getElement().getStyle().set(styleName, value));
         return get();

--- a/src/test/java/com/vaadin/flow/component/splitlayout/demo/SplitLayoutView.java
+++ b/src/test/java/com/vaadin/flow/component/splitlayout/demo/SplitLayoutView.java
@@ -15,14 +15,14 @@
  */
 package com.vaadin.flow.component.splitlayout.demo;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.splitlayout.SplitLayout;
 import com.vaadin.flow.component.splitlayout.SplitLayout.Orientation;
 import com.vaadin.flow.demo.DemoView;
 import com.vaadin.flow.router.Route;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * View for {@link SplitLayout} demo.
@@ -31,9 +31,6 @@ import com.vaadin.flow.router.Route;
  */
 @Route("vaadin-split-layout")
 public class SplitLayoutView extends DemoView {
-
-    private static final String FIRST_CONTENT_TEXT = "First content component";
-    private static final String SECOND_CONTENT_TEXT = "Second content component";
 
     @Override
     public void initView() {
@@ -46,13 +43,12 @@ public class SplitLayoutView extends DemoView {
     }
 
     private void addHorizontalLayout() {
-        Label firstLabel = new Label(FIRST_CONTENT_TEXT);
-        Label secondLabel = new Label(SECOND_CONTENT_TEXT);
         // begin-source-example
         // source-example-heading: Horizontal Split Layout (Default)
-        SplitLayout layout = new SplitLayout();
-        layout.addToPrimary(firstLabel);
-        layout.addToSecondary(secondLabel);
+
+        SplitLayout layout = new SplitLayout(
+                new Label("First content component"),
+                new Label("Second content component"));
         // end-source-example
 
         setMinHeightForLayout(layout);
@@ -73,40 +69,41 @@ public class SplitLayoutView extends DemoView {
     }
 
     private void addLayoutCombination() {
-        Label firstLabel = new Label(FIRST_CONTENT_TEXT);
-        Label secondLabel = new Label(SECOND_CONTENT_TEXT);
-        Label thirdLabel = new Label("Third content component");
         // begin-source-example
         // source-example-heading: Layout Combination
-        SplitLayout secondLayout = new SplitLayout();
-        secondLayout.setOrientation(Orientation.VERTICAL);
-        secondLayout.addToPrimary(secondLabel);
-        secondLayout.addToSecondary(thirdLabel);
+        Label firstLabel = new Label("First content component");
+        Label secondLabel = new Label("Second content component");
+        Label thirdLabel = new Label("Third content component");
+
+        SplitLayout innerLayout = new SplitLayout();
+        innerLayout.setOrientation(Orientation.VERTICAL);
+        innerLayout.addToPrimary(secondLabel);
+        innerLayout.addToSecondary(thirdLabel);
+
         SplitLayout layout = new SplitLayout();
         layout.addToPrimary(firstLabel);
-        layout.addToSecondary(secondLayout);
+        layout.addToSecondary(innerLayout);
         // end-source-example
 
         layout.getPrimaryComponent().setId("first-component");
         layout.getSecondaryComponent().setId("nested-layout");
-        secondLayout.getPrimaryComponent().setId("second-component");
-        secondLayout.getSecondaryComponent().setId("third-component");
+        innerLayout.getPrimaryComponent().setId("second-component");
+        innerLayout.getSecondaryComponent().setId("third-component");
         setMinHeightForLayout(layout);
         addCard("Layout Combination", layout);
     }
 
     private void addResizeNotificationLayout() {
-        Label firstLabel = new Label(FIRST_CONTENT_TEXT);
-        Label secondLabel = new Label(SECOND_CONTENT_TEXT);
         // begin-source-example
-        // source-example-heading: Resize Events
+        // source-example-heading: Resize Event
         SplitLayout layout = new SplitLayout();
-        layout.addToPrimary(firstLabel);
-        layout.addToSecondary(secondLabel);
-        Label message = new Label();
+        layout.addToPrimary(new Label("First content component"));
+        layout.addToSecondary(new Label("Second content component"));
+
+        Label message = new Label("Drag and drop the splitter");
         AtomicInteger resizeCounter = new AtomicInteger();
-        layout.addIronResizeListener(event -> message.setText(
-                "Resized " + resizeCounter.getAndIncrement() + " times."));
+        layout.addSplitterDragendListener(event -> message.setText(
+                "SplitLayout Resized " + resizeCounter.incrementAndGet() + " times."));
         // end-source-example
 
         message.setId("resize-message");
@@ -115,11 +112,11 @@ public class SplitLayoutView extends DemoView {
     }
 
     private void addInitialSplitterPositionLayout() {
-        Label firstLabel = new Label(FIRST_CONTENT_TEXT);
-        Label secondLabel = new Label(SECOND_CONTENT_TEXT);
-
         // begin-source-example
         // source-example-heading: Split Layout with Initial Splitter Position
+        Label firstLabel = new Label("First content component");
+        Label secondLabel = new Label("Second content component");
+
         SplitLayout layout = new SplitLayout(firstLabel, secondLabel);
         layout.setSplitterPosition(80);
         // end-source-example
@@ -131,15 +128,15 @@ public class SplitLayoutView extends DemoView {
     }
 
     private void addMinMaxWidthLayout() {
-        Label firstLabel = new Label(FIRST_CONTENT_TEXT);
-        Label secondLabel = new Label(SECOND_CONTENT_TEXT);
         // begin-source-example
         // source-example-heading: Split Layout with Minimum and Maximum Widths
         SplitLayout layout = new SplitLayout();
-        layout.addToPrimary(firstLabel);
-        layout.addToSecondary(secondLabel);
+        layout.addToPrimary(new Label("First content component"));
+        layout.addToSecondary(new Label("Second content component"));
+
         layout.setPrimaryStyle("minWidth", "100px");
         layout.setPrimaryStyle("maxWidth", "150px");
+        layout.setPrimaryStyle("background", "salmon");
         // end-source-example
 
         layout.getPrimaryComponent().setId("min-max-first-component");

--- a/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutIT.java
+++ b/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutIT.java
@@ -67,9 +67,13 @@ public class SplitLayoutIT extends ComponentDemoTest {
                 .moveByOffset(200, 0).release().build().perform();
 
         Assert.assertTrue("Resize events fired",
-                resizeMessage.getText().matches("Resized \\d+ times."));
-        Assert.assertTrue("More than 1 resize events fired",
-                !resizeMessage.getText().matches("Resized 1 times."));
+                resizeMessage.getText().matches("SplitLayout Resized 1 times."));
+
+        new Actions(getDriver()).dragAndDropBy(splitter, 1, 1).clickAndHold()
+                .moveByOffset(200, 0).release().build().perform();
+
+        Assert.assertTrue("Resize events fired",
+                resizeMessage.getText().matches("SplitLayout Resized 2 times."));
     }
 
     @Test

--- a/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
+++ b/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitLayoutUnitTest.java
@@ -1,0 +1,31 @@
+package com.vaadin.flow.component.splitlayout.tests;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.splitlayout.SplitLayout;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SplitLayoutUnitTest {
+
+    @Test
+    public void testGetOrientation_nothingSet_defaultReturnsHORIZONTAL() {
+        SplitLayout splitLayout = new SplitLayout();
+        Assert.assertEquals("Invalid default orientation", SplitLayout.Orientation.HORIZONTAL, splitLayout.getOrientation());
+    }
+
+    @Test
+    public void testAddingSeveralComponents_wrapsInDiv() {
+        SplitLayout splitLayout = new SplitLayout();
+        splitLayout.addToPrimary(new Label("1"), new Label("2"), new Label("3"));
+        splitLayout.addToSecondary(new Label("4"), new Label("5"));
+
+        Component primaryComponent = splitLayout.getPrimaryComponent();
+        Assert.assertEquals("No wrapper div", "div", primaryComponent.getElement().getTag());
+        Assert.assertEquals("Wrong number of children", 3, primaryComponent.getChildren().count());
+
+        Component secondaryComponent = splitLayout.getSecondaryComponent();
+        Assert.assertEquals("No wrapper div", "div", secondaryComponent.getElement().getTag());
+        Assert.assertEquals("Wrong number of children", 2, secondaryComponent.getChildren().count());
+    }
+}


### PR DESCRIPTION
- Hide IronResizeEvent API since it makes no on sense on server side
  - updated demo for this to use SplitterDragendEvent
- Added proper class javadocs for component on class level
- Adding getOrientation() and applying default orientation so it returns correct value
- Removed Fluent API from setters
- Fixed demo snippets not compiling
- Added some unit tests

Fixes website issues 2810, 2811, 2812

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-split-layout-flow/21)
<!-- Reviewable:end -->
