### PR TITLE
Use flexBasis for changing splitter position

### DIFF
--- a/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
+++ b/vaadin-split-layout-flow-integration-tests/src/test/java/com/vaadin/flow/component/splitlayout/tests/SplitterPositionIT.java
@@ -58,23 +58,29 @@ public class SplitterPositionIT extends AbstractComponentIT {
         TestBenchElement secondaryElement = layout.$(SpanElement.class)
                 .id("secondary" + testId);
         assertElementWidth(primaryElement,
-                (int) SplitterPositionView.INITIAL_POSITION + "%");
+                 SplitterPositionView.INITIAL_POSITION);
         assertElementWidth(secondaryElement,
-                (int) SplitterPositionView.FINAL_POSITION + "%");
+                 SplitterPositionView.FINAL_POSITION);
 
         $(NativeButtonElement.class).id("setSplitPosition" + testId).click();
         assertElementWidth(primaryElement,
-                (int) SplitterPositionView.FINAL_POSITION + "%");
+                 SplitterPositionView.FINAL_POSITION);
         assertElementWidth(secondaryElement,
-                (int) SplitterPositionView.INITIAL_POSITION + "%");
+                 SplitterPositionView.INITIAL_POSITION);
     }
 
-    private void assertElementWidth(TestBenchElement element, String expected) {
-        executeScript("console.log(arguments[0])", element);
-        executeScript("console.log(arguments[0].style)", element);
-        executeScript("console.log(arguments[0].style.width)", element);
-        Assert.assertEquals(expected,
-                element.getPropertyString("style", "width"));
+    private void assertElementWidth(TestBenchElement element, double expected) {
+        final double parentWidth = getWidth(element,".parentNode");
+        final double splitterWidth = getWidth(element,".parentNode.$.splitter");
+        final double calculatedExpectedWidth = expected * (parentWidth - splitterWidth) / 100d;
+        final double width = getWidth(element,"");
+        final double tolerance = 0.01; // 1% tolerance
+        Assert.assertTrue(Math.abs(calculatedExpectedWidth - width) < (calculatedExpectedWidth * tolerance));
     }
 
+    private double getWidth(TestBenchElement element, String path) {
+        final String sourcePath = "arguments[0]" + path;
+
+        return ((Number) executeScript("return " + sourcePath + ".getBoundingClientRect()['width']", element)).doubleValue();
+    }
 }

--- a/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
+++ b/vaadin-split-layout-flow/src/main/java/com/vaadin/flow/component/splitlayout/SplitLayout.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.dom.ElementConstants;
 import com.vaadin.flow.shared.Registration;
 
 /**

--- a/vaadin-split-layout-flow/src/main/resources/META-INF/resources/frontend/splitlayoutConnector.js
+++ b/vaadin-split-layout-flow/src/main/resources/META-INF/resources/frontend/splitlayoutConnector.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+(function () {
+  const tryCatchWrapper = function (callback) {
+    return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Split Layout', 'vaadin-split-layout-flow');
+  };
+
+  // Execute callback when predicate returns true.
+  // Try again later if predicate returns false.
+  function when(predicate, callback, timeout = 0) {
+      if (predicate()) {
+          callback();
+      } else {
+          setTimeout(() => when(predicate, callback, 200), timeout);
+      }
+  }
+
+  function _setSplitterPosition(splitlayout, position) {
+    const dimension = splitlayout.orientation === 'vertical' ? 'height' : 'width';
+
+    const getSize = (element) => element.getBoundingClientRect()[dimension];
+    const container =  getSize(splitlayout) - getSize(splitlayout.$.splitter);
+    const primary = getSize(splitlayout._primaryChild);
+    const secondary = getSize(splitlayout._secondaryChild);
+    const sum = primary + secondary;
+    const newPrimary = sum * position / 100;
+    const newSecondary = sum - newPrimary;
+
+    splitlayout._setFlexBasis(splitlayout._primaryChild, newPrimary, container);
+    splitlayout._setFlexBasis(splitlayout._secondaryChild, newSecondary, container);
+  }
+
+  function _setSplitterPositionWhenReady(splitlayout, position, waitForElements) {
+    const predicate = () => splitlayout._primaryChild && splitlayout._secondaryChild;
+    const callback = () => _setSplitterPosition(splitlayout, position);
+    if(waitForElements || splitlayout.children.length > 1) {
+      when(predicate, callback);
+    }
+  }
+
+  window.Vaadin.Flow.splitlayoutConnector = {
+    initLazy: function (splitlayout) {
+      if (splitlayout.$connector) {
+        return;
+      }
+      splitlayout.$connector = {
+        setSplitterPosition: tryCatchWrapper((position, waitForElements) => _setSplitterPositionWhenReady(splitlayout, position, waitForElements))
+      }
+    }
+  };
+})();


### PR DESCRIPTION
- Added connector with setSplitterPosition method that calculates and
sets flexBasis based on the percentage provided to setSplitterPosition
on server side.
- Replaced setting child element width with a call setSplitterPosition
method in connector.

Fixes #47